### PR TITLE
Uploaded Def14Perf11 test

### DIFF
--- a/ftp/tests/maximum_number_of_connections_test/docs.md
+++ b/ftp/tests/maximum_number_of_connections_test/docs.md
@@ -1,0 +1,13 @@
+# Test Case Description: Maximum Number of Connections Test
+
+This test aims at computing the maximmum number of concurrent connections supported by a Network Application.
+Given that the majority of the Network Applications rely on APIs, we can exercise these APIs to generate additional connections.
+Therefore, we use locust to perform a load test on one of the Network Application's API. Locust clients will generate various concurrent connections.
+
+The test flow is the following:
+
+1. Invoke the MiniAPI start test endpoint. Doing so will trigger the monitoring of the established connections
+2. Invoke the Locust Load Test to generate traffic to the Network Application (this relies on a 'host', 'endpoint' and 'http_method' parameters passed by the tester)
+3. Invoke the MiniAPI stop test endpoint. Will stop the monitoring of the established connections
+4. Invoke the MiniAPI test restults endpoint to gather a file with the recorded established connections
+5. Finally, evaluate the results agains the intended threshold

--- a/ftp/tests/maximum_number_of_connections_test/locust_performance_test.py
+++ b/ftp/tests/maximum_number_of_connections_test/locust_performance_test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:06:27
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2023-12-29 17:09:16
+from locust import HttpUser, task, between, events
+import os
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument("--endpoint", type=str, env_var="ENDPOINT")
+    parser.add_argument("--http-method", type=str, env_var="HTTP_METHOD")
+
+
+class NetworkApplicationUser(HttpUser):
+    host = os.getenv("HOST")
+    wait_time = between(1, 2)
+
+    @task
+    def performance_task(self):
+        endpoint = self.environment.parsed_options.endpoint
+        http_method = self.environment.parsed_options.http_method
+
+        if endpoint is None or http_method is None:
+            raise ValueError("Missing endpoint or http_method")
+
+        http_method = http_method.upper()
+        if http_method not in ["GET", "POST"]:
+            raise ValueError(f"Unsupported HTTP method: {http_method}")
+
+        if http_method == "GET":
+            self.client.get(endpoint)
+        elif http_method == "POST":
+            self.client.post(endpoint)

--- a/ftp/tests/maximum_number_of_connections_test/maximum_number_of_connections_test.py
+++ b/ftp/tests/maximum_number_of_connections_test/maximum_number_of_connections_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-29 16:40:46
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2023-12-29 17:14:40
+import requests
+
+
+def start_mini_api_test(mini_api_start_endpoint_to_invoke):
+    response = requests.post(mini_api_start_endpoint_to_invoke)
+
+    if response.status_code not in [200, 201, 409]:
+        return False
+    print(f"START Response: {response.text}")
+    return True
+
+
+def stop_mini_api_test(mini_api_stop_endpoint_to_invoke):
+    response = requests.post(mini_api_stop_endpoint_to_invoke)
+
+    if response.status_code not in [200, 409]:
+        return False
+    print(f"STOP Response: {response.text}")
+    return True
+
+
+def get_results_and_evaluate_them(mini_api_results_endpoint_to_invoke):
+    maximum_number_of_connections = 0
+    print("Connections recording file content:")
+    try:
+        # Make a GET request to the API
+        response = requests.get(mini_api_results_endpoint_to_invoke)
+
+        # Check if the request was successful (status code 200)
+        if response.status_code == 200:
+            # Iterate through each line in the response text and print it
+            for line in response.text.splitlines():
+                print(line)
+                try:
+                    connections = int(line.strip())
+                    if connections > maximum_number_of_connections:
+                        maximum_number_of_connections = connections
+                except Exception:
+                    pass
+            return maximum_number_of_connections
+        else:
+            print(f"Error: {response.status_code} - {response.text}")
+            return -1
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return -1

--- a/ftp/tests/maximum_number_of_connections_test/maximum_number_of_connections_test.robot
+++ b/ftp/tests/maximum_number_of_connections_test/maximum_number_of_connections_test.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+Library    Process
+Library    maximum_number_of_connections_test.py
+
+
+*** Test Cases ***
+Run Locust Requests Per Second Test
+    # Log Initial Input
+    Log    Load Test Host: %{maximum_number_of_connections_test_load_test_host}
+    Log    Load Test endpoint: %{maximum_number_of_connections_test_load_test_endpoint}
+    Log    Load Test HTTP Method: %{maximum_number_of_connections_test_load_test_http_method}
+    Run Keyword    Log To Console    \n\Load Test Host: %{maximum_number_of_connections_test_load_test_host}
+    Run Keyword    Log To Console    \nLoad Test  endpoint: %{maximum_number_of_connections_test_load_test_endpoint}
+    Run Keyword    Log To Console    \nLoad Test  HTTP Method: %{maximum_number_of_connections_test_load_test_http_method}
+    # Start the test in the MiniAPI
+    ${mini_api_test_started}=  Start Mini Api Test    %{maximum_number_of_connections_test_mini_api_endpoint_to_invoke}
+    # Check if the test was started in the MiniAPI
+    Should Be True  ${mini_api_test_started}
+    # Afer this we will have to generate some load, to evaluate how many
+    # connections does the Network Application Handle.
+    # This Locust Process will spwan 100 users at once and will try to make
+    # requests to the target during 20 seconds. These user are used to generat
+    # TCP connections with one of the Networok Application's API
+    ${output}=    Run Process   locust    -f    locust_performance_test.py    --headless    -u    100    -r    50    --run-time    20    --host    %{maximum_number_of_connections_test_load_test_host}    --endpoint    %{maximum_number_of_connections_test_load_test_endpoint}    --http-method    %{maximum_number_of_connections_test_load_test_http_method}    --json
+    Log    ${output.stdout} 
+    Run Keyword    Log To Console    \nLocust Output:\n ${output.stdout}
+    # Now we can stop the test
+    ${mini_api_test_stopped}=  Stop Mini Api Test    %{maximum_number_of_connections_test_mini_api_endpoint_to_invoke_cleanup}
+    # Check if the test was stopped in the MiniAPI
+    Should Be True  ${mini_api_test_stopped}
+    # Now we must invoke the /results endpoint of the MiniAPI to get the test
+    # outcomes and evaluate them
+    ${maximum_achieved_connections}=  Get Results And Evaluate Them    %{maximum_number_of_connections_test_mini_api_endpoint_to_invoke_results}
+    Log    \nMaximum Number Of Connections: ${maximum_achieved_connections}
+    Run Keyword    Log To Console   \nMaximum Number Of Connections: ${maximum_achieved_connections}
+    # Now, we have to evaluate the results agains the minimum threshold for
+    # the number concurrent connections
+    IF    ${maximum_achieved_connections} >= %{maximum_number_of_connections_test_connections_minimum_threshold}
+        Pass Execution    \n\nThe Target Server/API COMPLIES with the minimum threshold set for number of concurrent connections (%{maximum_number_of_connections_test_connections_minimum_threshold}).\n
+    ELSE
+        Fail  \n\nThe Target Server/API DOES NOT comply with the minimum threshold set for number of concurrent connections(%{maximum_number_of_connections_test_connections_minimum_threshold}).\n
+    END

--- a/ftp/tests/maximum_number_of_connections_test/requirements.txt
+++ b/ftp/tests/maximum_number_of_connections_test/requirements.txt
@@ -1,0 +1,3 @@
+robotframework==6.0.2
+locust==2.20.0
+requests==2.31.0

--- a/ftp/tests/maximum_number_of_connections_test/run_test.sh
+++ b/ftp/tests/maximum_number_of_connections_test/run_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:01:32
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2023-12-29 17:16:24
+
+export maximum_number_of_connections_test_load_test_host=http://10.255.28.230:8080
+export maximum_number_of_connections_test_load_test_endpoint=/
+export maximum_number_of_connections_test_load_test_http_method=GET
+export maximum_number_of_connections_test_mini_api_endpoint_to_invoke=http://10.255.28.230:8000/start/Def14Perf11
+export maximum_number_of_connections_test_mini_api_endpoint_to_invoke_cleanup=http://10.255.28.230:8000/stop/Def14Perf11
+export maximum_number_of_connections_test_mini_api_endpoint_to_invoke_results=http://10.255.28.230:8000/results/Def14Perf11
+export maximum_number_of_connections_test_connections_minimum_threshold=10
+python3 -m robot .


### PR DESCRIPTION
(Closes #18)

This PR provides the implementation of the following test:

**Test Case Name:** Network Application: Network Application - API performance - maximum number of connections
**Test Case Description:** Validate by measuring the maximum number of simultaneous connections established to the Network Application.

This was a tricky test to implement, given that it is necessary to load test the Network Application in order to generate new concurrent connections. This is described in the `docs.md` file uploaded in this PR. Please read this file before testing if this test works properly.

@eduardosantoshf 
Can you please test this?
You may need a dummy API running in the same host as the MiniAPI. 
Here is one you may use (it was the one I used to test this test):

``` python
import cherrypy

class HelloWorldApp:
    @cherrypy.expose
    def index(self):
        return "Hello World"

if __name__ == "__main__":
    cherrypy.config.update(
        {
            'server.socket_host': '0.0.0.0',
            'server.socket_port': 8080
        }
    )
    cherrypy.quickstart(HelloWorldApp())
``` 

`pip install cherrypy` + `python3 app.py` is enough to run this API. 
 