### PR TITLE
Enhancement/#26 - Implements def14.Perf.5 and def14.Perf.6

### DIFF
--- a/ftp/tests/nef_signaling_performance_requests_per_second_test/locust_performance_test.py
+++ b/ftp/tests/nef_signaling_performance_requests_per_second_test/locust_performance_test.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:06:27
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-04 10:33:03
+from locust import HttpUser, task, between, events
+import os
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument("--endpoint", type=str, env_var="ENDPOINT")
+
+
+class NetworkApplicationUser(HttpUser):
+    host = os.getenv("HOST")
+    wait_time = between(1, 3)
+
+    @task
+    def performance_task(self):
+        endpoint = self.environment.parsed_options.endpoint
+
+        if endpoint is None:
+            raise ValueError("Missing endpoint.")
+
+        self.client.post(
+            endpoint,
+            json={
+                "externalId": "10001@domain.com",
+                "ipv4Addr": "10.0.0.1",
+                "subscription": "4a21f2e1-67eb-4d0b-9e5c-7b1d20e07b7d",
+                "monitoringType": "LOCATION_REPORTING",
+                "locationInfo": {
+                    "cellId": "AAAAA1001",
+                    "enodeBId": "AAAAA1"
+                }
+            }
+        )

--- a/ftp/tests/nef_signaling_performance_requests_per_second_test/nef_signaling_performance_requests_per_second_test.py
+++ b/ftp/tests/nef_signaling_performance_requests_per_second_test/nef_signaling_performance_requests_per_second_test.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:45:52
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2023-12-28 11:14:29
+import json
+import statistics
+
+
+def evaluate_locust_results(results_json):
+    # Print the results
+    print("LOCUST RESULTS:")
+    print(results_json)
+
+    # Load the locust results and compute the final test result
+    results = json.loads(results_json)[0]
+
+    num_requests_per_second = [
+        v
+        for v
+        in results["num_reqs_per_sec"].values()
+    ]
+
+    print(f"Test Duration: {len(num_requests_per_second)} seconds.")
+
+    mean_requests_per_second = statistics.mean(num_requests_per_second)
+    print("Mean Requests per Second:", mean_requests_per_second)
+
+    median_requests_per_second = statistics.median(num_requests_per_second)
+    print("Median Requests per Second:", median_requests_per_second)
+
+    # Return the final result
+    return median_requests_per_second

--- a/ftp/tests/nef_signaling_performance_requests_per_second_test/nef_signaling_performance_requests_per_second_test.robot
+++ b/ftp/tests/nef_signaling_performance_requests_per_second_test/nef_signaling_performance_requests_per_second_test.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Library    Process
+Library    nef_signaling_performance_requests_per_second_test.py
+
+
+*** Test Cases ***
+Run Locust Requests Per Second Test
+    # Log Initial Input
+    Log    Test Host: %{nef_signaling_performance_requests_per_second_test_host}
+    Log    Test endpoint: %{nef_signaling_performance_requests_per_second_test_endpoint}
+    Log    Minimum Threshhold - Requests Per Second: %{nef_signaling_performance_requests_per_second_test_min_threshold} requests/sec.
+    Run Keyword    Log To Console    \n\nTest Host: %{nef_signaling_performance_requests_per_second_test_host}
+    Run Keyword    Log To Console    \nTest endpoint: %{nef_signaling_performance_requests_per_second_test_endpoint}
+    Run Keyword    Log To Console    \nMinimum Threshhold - Requests Per Second: %{nef_signaling_performance_requests_per_second_test_min_threshold} requests/sec.
+    # This Locust Process will spwan 20 users at once and will try to make
+    # requests to the target during 10 seconds.
+    # The locust test result is a JSON that will be processed by a python
+    # library to evaluate if the target api/server complies with the desired
+    # number of requests served per seconds.  
+    ${output}=    Run Process   locust    -f    locust_performance_test.py    --headless    -u    25    -r    25    --run-time    10    --host    %{nef_signaling_performance_requests_per_second_test_host}    --endpoint    %{nef_signaling_performance_requests_per_second_test_endpoint}    --json
+    #Log    ${output.stdout} # This can be used for debugging
+    ${median_requests_per_second}=    Evaluate Locust Results    ${output.stdout}
+    # Log the result
+    Log    Median Requests Per Second: ${median_requests_per_second} requests/sec.
+    Run Keyword    Log To Console    \n\n[RESULT] Median Requests Per Second: ${median_requests_per_second} requests/sec.\n
+    
+    # Now, we have to evaluate the results agains the minimum threshold for
+    # the number of requests per second
+    IF    ${median_requests_per_second} >= %{nef_signaling_performance_requests_per_second_test_min_threshold}
+        Pass Execution    \n\nThe Target Server/API COMPLIES with the minimum threshold set for number of requests/sec (%{nef_signaling_performance_requests_per_second_test_min_threshold}).\n
+    ELSE
+        Fail  \n\nThe Target Server/API DOES NOT comply with the minimum threshold set for number of requests/sec (%{nef_signaling_performance_requests_per_second_test_min_threshold}).\n
+    END

--- a/ftp/tests/nef_signaling_performance_requests_per_second_test/requirements.txt
+++ b/ftp/tests/nef_signaling_performance_requests_per_second_test/requirements.txt
@@ -1,0 +1,2 @@
+robotframework==6.0.2
+locust==2.20.0

--- a/ftp/tests/nef_signaling_performance_requests_per_second_test/run_test.sh
+++ b/ftp/tests/nef_signaling_performance_requests_per_second_test/run_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:01:32
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-04 10:33:46
+
+export nef_signaling_performance_requests_per_second_test_host=https://webhook.site
+export nef_signaling_performance_requests_per_second_test_endpoint=/a0399d20-64db-4194-985e-ff447772e4d8
+export nef_signaling_performance_requests_per_second_test_min_threshold=10
+python3 -m robot .

--- a/ftp/tests/nef_signaling_performance_response_time_test/locust_performance_test.py
+++ b/ftp/tests/nef_signaling_performance_response_time_test/locust_performance_test.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:06:27
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-04 09:55:05
+from locust import HttpUser, task, between, events
+import os
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument("--endpoint", type=str, env_var="ENDPOINT")
+
+
+class NetworkApplicationUser(HttpUser):
+    host = os.getenv("HOST")
+    wait_time = between(1, 3)
+
+    @task
+    def performance_task(self):
+        endpoint = self.environment.parsed_options.endpoint
+
+        if endpoint is None:
+            raise ValueError("Missing endpoint.")
+
+        self.client.post(
+            endpoint,
+            json={
+                "externalId": "10001@domain.com",
+                "ipv4Addr": "10.0.0.1",
+                "subscription": "4a21f2e1-67eb-4d0b-9e5c-7b1d20e07b7d",
+                "monitoringType": "LOCATION_REPORTING",
+                "locationInfo": {
+                    "cellId": "AAAAA1001",
+                    "enodeBId": "AAAAA1"
+                }
+            }
+        )

--- a/ftp/tests/nef_signaling_performance_response_time_test/nef_signaling_performance_response_time_test.py
+++ b/ftp/tests/nef_signaling_performance_response_time_test/nef_signaling_performance_response_time_test.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:45:52
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-04 10:10:44
+import json
+
+
+def evaluate_locust_results(results_json):
+    # Print the results
+    print("LOCUST RESULTS:")
+    print(results_json)
+
+    # Load the locust results and compute the final test result
+    results = json.loads(results_json)[0]
+
+    total_requests = results["num_requests"] - results["num_failures"]
+    print(f"Number of requests made: {total_requests}.")
+
+    total_response_time = results["total_response_time"] / 1000
+    print(f"Total Response Time: {total_response_time} sec.")
+
+    avg_response_time = total_response_time / total_requests
+
+    # Return the final result
+    return avg_response_time

--- a/ftp/tests/nef_signaling_performance_response_time_test/nef_signaling_performance_response_time_test.robot
+++ b/ftp/tests/nef_signaling_performance_response_time_test/nef_signaling_performance_response_time_test.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Library    Process
+Library    nef_signaling_performance_response_time_test.py
+
+
+*** Test Cases ***
+Run Locust Requests Per Second Test
+    # Log Initial Input
+    Log    Test Host: %{nef_signaling_performance_response_time_test_host}
+    Log    Test endpoint: %{nef_signaling_performance_response_time_test_endpoint}
+    Log    Maximum Threshhold - Response Time: %{nef_signaling_performance_response_time_test_max_response_time_threshold_secs} secs.
+    Run Keyword    Log To Console    \n\nTest Host: %{nef_signaling_performance_response_time_test_host}
+    Run Keyword    Log To Console    \nTest endpoint: %{nef_signaling_performance_response_time_test_endpoint}
+    Run Keyword    Log To Console    \nMaximum Threshhold - Response Time: %{nef_signaling_performance_response_time_test_max_response_time_threshold_secs} secs.
+    # This Locust Process will spwan 25 users at once and will try to make
+    # requests to the target during 10 seconds.
+    # The locust test result is a JSON that will be processed by a python
+    # library to evaluate if the target api/server complies with the desired
+    # number of requests served per seconds.  
+    ${output}=    Run Process   locust    -f    locust_performance_test.py    --headless    -u    25    -r    25    --run-time    10    --host    %{nef_signaling_performance_response_time_test_host}    --endpoint    %{nef_signaling_performance_response_time_test_endpoint}    --json
+    Log    ${output.stdout}
+    
+    ${avg_response_time}=    Evaluate Locust Results    ${output.stdout}
+    # Log the result
+    Log    Average Response Time: ${avg_response_time} sec.
+    Run Keyword    Log To Console    \n\n[RESULT] Average Response Time: ${avg_response_time} sec.\n
+
+    # Now, we have to evaluate the results agains the minimum threshold for
+    # the number of requests per second
+    IF    ${avg_response_time} <= %{nef_signaling_performance_response_time_test_max_response_time_threshold_secs}
+        Pass Execution    \n\nThe Target Server/API COMPLIES with the maximum threshold set for the response time (%{nef_signaling_performance_response_time_test_max_response_time_threshold_secs} secs).\n
+    ELSE
+        Fail  \n\nThe Target Server/API DOES NOT comply with the maximum threshold set for the response time (%{nef_signaling_performance_response_time_test_max_response_time_threshold_secs} secs).\n
+    END

--- a/ftp/tests/nef_signaling_performance_response_time_test/requirements.txt
+++ b/ftp/tests/nef_signaling_performance_response_time_test/requirements.txt
@@ -1,0 +1,2 @@
+robotframework==6.0.2
+locust==2.20.0

--- a/ftp/tests/nef_signaling_performance_response_time_test/run_test.sh
+++ b/ftp/tests/nef_signaling_performance_response_time_test/run_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:01:32
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-04 10:10:59
+
+export nef_signaling_performance_response_time_test_host=https://webhook.site
+export nef_signaling_performance_response_time_test_endpoint=/a0399d20-64db-4194-985e-ff447772e4d8
+export nef_signaling_performance_response_time_test_max_response_time_threshold_secs=2
+python3 -m robot .


### PR DESCRIPTION
(Closes #26)
This PR provides the implementation of the following tests:

**[def14.Perf.5]**
**Test Case:** NEF signaling performance - response time
**Test Description:** Validate by measuring NEF API response time.

**[def14.Perf.6]**
**Test Case:** NEF signaling performance - requests per second
**Test Description:** Validate by measuring how many requests the NEF API can serve per second.

**Additional Information:**
The NEF's signaling performance will vary based on the Network Application's API that will receive the callbacks from the NEF.
Therefore, we must validate that this API can process the callbacks in a given time period and can also support various simultaneous callback notifications (i.e. requests). This can be validated using locust by sending a notification callback to the desired API.
The payload of the callbacks can be found at https://github.com/5gasp/NEF-Emulator/blob/main/backend/app/app/tools/monitoring_callbacks.py#L3.

These two tests will stress the API receiving the callbacks by sending several requests with the previous payload.

@eduardosantoshf 
Can you please review this?