### PR TITLE
Enhancement/#28 - Implements def14.Perf.7

### DIFF
--- a/ftp/tests/nef_signaling_performance_maximum_connections_test/docs.md
+++ b/ftp/tests/nef_signaling_performance_maximum_connections_test/docs.md
@@ -1,0 +1,12 @@
+# Test Case Description: NEF Signaling API - Maximum Number of Connections Test
+
+This test aims at computing the maximmum number of concurrent connections supported by the Network Application's API that will receive the NEF Callbacks.
+We use locust to perform a load test on one of the NEF Callback API. Locust clients will generate various concurrent connections.
+
+The test flow is the following:
+
+1. Invoke the MiniAPI start test endpoint. Doing so will trigger the monitoring of the established connections
+2. Invoke the Locust Load Test to generate traffic to the Network Application (this relies on a 'host' and 'endpoint' parameters passed by the tester)
+3. Invoke the MiniAPI stop test endpoint. Will stop the monitoring of the established connections
+4. Invoke the MiniAPI test restults endpoint to gather a file with the recorded established connections
+5. Finally, evaluate the results agains the intended threshold

--- a/ftp/tests/nef_signaling_performance_maximum_connections_test/locust_performance_test.py
+++ b/ftp/tests/nef_signaling_performance_maximum_connections_test/locust_performance_test.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:06:27
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-05 08:27:51
+from locust import HttpUser, task, between, events
+import os
+
+
+@events.init_command_line_parser.add_listener
+def _(parser):
+    parser.add_argument("--endpoint", type=str, env_var="ENDPOINT")
+
+
+class NetworkApplicationUser(HttpUser):
+    host = os.getenv("HOST")
+    wait_time = between(1, 3)
+
+    @task
+    def performance_task(self):
+        endpoint = self.environment.parsed_options.endpoint
+
+        if endpoint is None:
+            raise ValueError("Missing endpoint.")
+
+        self.client.post(
+            endpoint,
+            json={
+                "externalId": "10001@domain.com",
+                "ipv4Addr": "10.0.0.1",
+                "subscription": "4a21f2e1-67eb-4d0b-9e5c-7b1d20e07b7d",
+                "monitoringType": "LOCATION_REPORTING",
+                "locationInfo": {
+                    "cellId": "AAAAA1001",
+                    "enodeBId": "AAAAA1"
+                }
+            }
+        )

--- a/ftp/tests/nef_signaling_performance_maximum_connections_test/nef_signaling_performance_maximum_connections_test.py
+++ b/ftp/tests/nef_signaling_performance_maximum_connections_test/nef_signaling_performance_maximum_connections_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-12-29 16:40:46
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2023-12-29 17:14:40
+import requests
+
+
+def start_mini_api_test(mini_api_start_endpoint_to_invoke):
+    response = requests.post(mini_api_start_endpoint_to_invoke)
+
+    if response.status_code not in [200, 201, 409]:
+        return False
+    print(f"START Response: {response.text}")
+    return True
+
+
+def stop_mini_api_test(mini_api_stop_endpoint_to_invoke):
+    response = requests.post(mini_api_stop_endpoint_to_invoke)
+
+    if response.status_code not in [200, 409]:
+        return False
+    print(f"STOP Response: {response.text}")
+    return True
+
+
+def get_results_and_evaluate_them(mini_api_results_endpoint_to_invoke):
+    maximum_number_of_connections = 0
+    print("Connections recording file content:")
+    try:
+        # Make a GET request to the API
+        response = requests.get(mini_api_results_endpoint_to_invoke)
+
+        # Check if the request was successful (status code 200)
+        if response.status_code == 200:
+            # Iterate through each line in the response text and print it
+            for line in response.text.splitlines():
+                print(line)
+                try:
+                    connections = int(line.strip())
+                    if connections > maximum_number_of_connections:
+                        maximum_number_of_connections = connections
+                except Exception:
+                    pass
+            return maximum_number_of_connections
+        else:
+            print(f"Error: {response.status_code} - {response.text}")
+            return -1
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return -1

--- a/ftp/tests/nef_signaling_performance_maximum_connections_test/nef_signaling_performance_maximum_connections_test.robot
+++ b/ftp/tests/nef_signaling_performance_maximum_connections_test/nef_signaling_performance_maximum_connections_test.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Library    Process
+Library    nef_signaling_performance_maximum_connections_test.py
+
+
+*** Test Cases ***
+Run Locust Requests Per Second Test
+    # Log Initial Input
+    Log    Load Test Host: %{nef_signaling_performance_maximum_connections_test_load_test_host}
+    Log    Load Test endpoint: %{nef_signaling_performance_maximum_connections_test_load_test_endpoint}
+    Run Keyword    Log To Console    \n\Load Test Host: %{nef_signaling_performance_maximum_connections_test_load_test_host}
+    Run Keyword    Log To Console    \nLoad Test  endpoint: %{nef_signaling_performance_maximum_connections_test_load_test_endpoint}
+    # Start the test in the MiniAPI
+    ${mini_api_test_started}=  Start Mini Api Test    %{nef_signaling_performance_maximum_connections_test_mini_api_endpoint_to_invoke}
+    # Check if the test was started in the MiniAPI
+    Should Be True  ${mini_api_test_started}
+    # Afer this we will have to generate some load, to evaluate how many
+    # connections does the Network Application Handle.
+    # This Locust Process will spwan 100 users at once and will try to make
+    # requests to the target during 20 seconds. These user are used to generat
+    # TCP connections with one of the Networok Application's API
+    ${output}=    Run Process   locust    -f    locust_performance_test.py    --headless    -u    25    -r    25    --run-time    20    --host    %{nef_signaling_performance_maximum_connections_test_load_test_host}    --endpoint    %{nef_signaling_performance_maximum_connections_test_load_test_endpoint}    --json
+    Log    ${output.stdout} 
+    Run Keyword    Log To Console    \nLocust Output:\n ${output.stdout}
+    # Now we can stop the test
+    ${mini_api_test_stopped}=  Stop Mini Api Test    %{nef_signaling_performance_maximum_connections_test_mini_api_endpoint_to_invoke_cleanup}
+    # Check if the test was stopped in the MiniAPI
+    Should Be True  ${mini_api_test_stopped}
+    # Now we must invoke the /results endpoint of the MiniAPI to get the test
+    # outcomes and evaluate them
+    ${maximum_achieved_connections}=  Get Results And Evaluate Them    %{nef_signaling_performance_maximum_connections_test_mini_api_endpoint_to_invoke_results}
+    Log    \nMaximum Number Of Connections: ${maximum_achieved_connections}
+    Run Keyword    Log To Console   \nMaximum Number Of Connections: ${maximum_achieved_connections}
+    # Now, we have to evaluate the results agains the minimum threshold for
+    # the number concurrent connections
+    IF    ${maximum_achieved_connections} >= %{nef_signaling_performance_maximum_connections_test_connections_minimum_threshold}
+        Pass Execution    \n\nThe Target Server/API COMPLIES with the minimum threshold set for number of concurrent connections (%{nef_signaling_performance_maximum_connections_test_connections_minimum_threshold}).\n
+    ELSE
+        Fail  \n\nThe Target Server/API DOES NOT comply with the minimum threshold set for number of concurrent connections(%{nef_signaling_performance_maximum_connections_test_connections_minimum_threshold}).\n
+    END

--- a/ftp/tests/nef_signaling_performance_maximum_connections_test/requirements.txt
+++ b/ftp/tests/nef_signaling_performance_maximum_connections_test/requirements.txt
@@ -1,0 +1,3 @@
+robotframework==6.0.2
+locust==2.20.0
+requests==2.31.0

--- a/ftp/tests/nef_signaling_performance_maximum_connections_test/run_test.sh
+++ b/ftp/tests/nef_signaling_performance_maximum_connections_test/run_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# @Author: Rafael Direito
+# @Date:   2023-12-28 10:01:32
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-05 08:28:18
+
+export nef_signaling_performance_maximum_connections_test_load_test_host=http://10.255.28.230:8080
+export nef_signaling_performance_maximum_connections_test_load_test_endpoint=/
+export nef_signaling_performance_maximum_connections_test_mini_api_endpoint_to_invoke=http://10.255.28.230:8000/start/Def14Perf7
+export nef_signaling_performance_maximum_connections_test_mini_api_endpoint_to_invoke_cleanup=http://10.255.28.230:8000/stop/Def14Perf7
+export nef_signaling_performance_maximum_connections_test_mini_api_endpoint_to_invoke_results=http://10.255.28.230:8000/results/Def14Perf7
+export nef_signaling_performance_maximum_connections_test_connections_minimum_threshold=2
+python3 -m robot .


### PR DESCRIPTION
(Closes #28)

**[def14.Perf.7]**
**Test Case:** NEF signaling performance - maximum number of connections
**Test Description:** Validate by measuring the maximum number of simultaneous connections established to the NEF API.

This test is quite similar to the one uploaded via the Pull Request: https://github.com/5gasp/CICD_LTR/pull/19 

@eduardosantoshf 
Can you please test this?
You may need a dummy API running in the same host as the MiniAPI. 
Here is one you may use (it was the one I used to test this test):

``` python
class HelloWorldApp:
    @cherrypy.expose
    def index(self):
        return "Hello World"

    @cherrypy.expose
    @cherrypy.tools.json_in()
    def default(self, *args, **kwargs):
        if cherrypy.request.method == 'POST':
            data = cherrypy.request.json
            if data:
                print("Received POST request with payload:")
                print(data)
            else:
                print("Received POST request with no payload.")
            return "POST request handled"
        else:
            return "Unsupported method"


if __name__ == "__main__":
    cherrypy.config.update(
        {
            'server.socket_host': '0.0.0.0',
            'server.socket_port': 8080
        }
    )
    cherrypy.quickstart(HelloWorldApp())
``` 

`pip install cherrypy` + `python3 app.py` is enough to run this API. 

Take into consideration this PR: https://github.com/5gasp/NetworkAppControl-MiniAPI/pull/13