### PR TITLE
Fix: Test def11.5G.7 

### DIFF
--- a/ftp/tests/mini_api_configuration/run_test.sh
+++ b/ftp/tests/mini_api_configuration/run_test.sh
@@ -2,10 +2,10 @@
 # @Author: Rafael Direito
 # @Date:   2023-05-22 15:42:35
 # @Last Modified by:   Eduardo Santos
-# @Last Modified time: 2023-12-31 17:55:26
+# @Last Modified time: 2024-01-05 19:47:09
 
 export mini_api_configuration_api_ip=10.255.28.206
-export mini_api_configuration_api_port=3001
+export mini_api_configuration_api_port=8000
 export mini_api_configuration_configuration_payload='{"variables":{"NEF_IP":"10.255.28.173","NEF_PORT":8888,"NEF_LOGIN_USERNAME":"admin@my-email.com","NEF_LOGIN_PASSWORD":"pass","SUBS1_MONITORING_TYPE":"LOCATION_REPORTING","SUBS1_CALLBACK_URL":"http://127.0.0.1/callback","SUBS1_MONITORING_EXPIRE_TIME":"2024-03-09T13:18:19.495000+00:00","UE1_NAME":"My UE","UE1_DESCRIPTION":"My UE Description","UE1_IPV4":"10.10.10.10","UE1_IPV6":"0:0:0:0:0:0:0:0","UE1_MAC_ADDRESS":"22-00-00-00-00-02","UE1_SUPI":"202010000000001"}}'
 python3 -m robot .
 

--- a/ftp/tests/nef_authentication_test/run_test.sh
+++ b/ftp/tests/nef_authentication_test/run_test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # @Author: Rafael Direito
 # @Date:   2023-05-22 15:42:35
-# @Last Modified by:   Rafael Direito
-# @Last Modified time: 2023-05-31 16:10:34
+# @Last Modified by:   Eduardo Santos
+# @Last Modified time: 2024-01-05 19:47:20
 
 export nef_authentication_test_reporting_api_ip=10.255.28.173
 export nef_authentication_test_reporting_api_port=3000
-export nef_authentication_test_mini_api_endpoint_to_invoke=http://10.255.28.206:3001/start/1
+export nef_authentication_test_mini_api_endpoint_to_invoke=http://10.255.28.206:8000/start/1
 python3 -m robot .

--- a/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.py
+++ b/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.py
@@ -2,7 +2,7 @@
 # @Author: Eduardo Santos
 # @Date:   2023-12-31 17:02:22
 # @Last Modified by:   Eduardo Santos
-# @Last Modified time: 2023-12-31 18:38:42
+# @Last Modified time: 2024-01-05 19:38:26
 
 
 # Return Codes:
@@ -33,14 +33,17 @@ def validate_report(report):
 
 
 def test_nef_qos_subscription(
-    mini_api_endpoint_to_invoke, reporting_api_ip, reporting_api_port
+    mini_api_endpoint_to_invoke, reporting_api_ip, reporting_api_port, monitoring_payload
 ):
 
     # 1. Trigger MiniAPIs endpoint
     print("Entering...")
     response = None
     try:
-        response = requests.post(mini_api_endpoint_to_invoke)
+        response = requests.post(
+            url=mini_api_endpoint_to_invoke, 
+            data=monitoring_payload
+        )
 
         if response.status_code not in [200, 409]:
             response.raise_for_status()    

--- a/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.py
+++ b/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # @Author: Eduardo Santos
 # @Date:   2023-12-31 17:02:22
-# @Last Modified by:   Eduardo Santos
-# @Last Modified time: 2024-01-05 19:38:26
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-06 11:28:24
 
 
 # Return Codes:
@@ -19,7 +19,8 @@ def validate_report(report):
     for i in range(len(report)-1, -1, -1):
         request = report[i]
         if (
-            request["endpoint"] == f"/api/v1/3gpp-as-session-with-qos/v1/netapp/subscriptions"
+            request["endpoint"] == "/api/v1/3gpp-as-session-with-qos/v1/"
+            "netapp/subscriptions"
             and
             request["method"] == "POST"
         ):
@@ -33,20 +34,20 @@ def validate_report(report):
 
 
 def test_nef_qos_subscription(
-    mini_api_endpoint_to_invoke, reporting_api_ip, reporting_api_port, monitoring_payload
+    mini_api_endpoint_to_invoke, reporting_api_ip, reporting_api_port,
+    monitoring_payload
 ):
-
     # 1. Trigger MiniAPIs endpoint
     print("Entering...")
     response = None
     try:
         response = requests.post(
-            url=mini_api_endpoint_to_invoke, 
+            url=mini_api_endpoint_to_invoke,
             data=monitoring_payload
         )
 
         if response.status_code not in [200, 409]:
-            response.raise_for_status()    
+            response.raise_for_status()
         print(f"Response: {response.text}")
     except Exception as e:
         error = response.text if response else None
@@ -80,7 +81,7 @@ def test_nef_qos_subscription(
         print(f"Test Failed due to the following errors: {errors_str}")
         return 1, f"Test Failed due to the following errors: {errors_str}"
 
-    print("Test Successful! NApp was able to subscribe a QoS compromised " \
+    print("Test Successful! NApp was able to subscribe a QoS compromised "
           "event in the  NEF")
-    return 0, "Test Successful! NApp was able to subscribe a QoS compromised " \
-          "event in the  NEF"
+    return 0, "Test Successful! NApp was able to subscribe a QoS compromised "\
+        "event in the  NEF"

--- a/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.robot
+++ b/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.robot
@@ -4,7 +4,21 @@ Library    nef_qos_subscription_test.py
 
 *** Test Cases ***
 NEF's QoS Subscription Test
+    # Start by logging the test parameters/inputs
+    Log    MiniAPI endpoint to invoke: %{nef_qos_subscription_test_mini_api_endpoint_to_invoke}
+    Log    Reporting API IP: %{nef_qos_subscription_test_reporting_api_ip}
+    Log    Reporting API Port: %{nef_qos_subscription_test_reporting_api_port}
+    Log    Monitoring Payload: %{nef_qos_subscription_test_monitoring_payload}
+    Run Keyword    Log to Console    \nMiniAPI endpoint to invoke: %{nef_qos_subscription_test_mini_api_endpoint_to_invoke}
+    Run Keyword    Log to Console    Reporting API IP: %{nef_qos_subscription_test_reporting_api_ip}
+    Run Keyword    Log to Console    Reporting API Port: %{nef_qos_subscription_test_reporting_api_port}
+    Run Keyword    Log to Console    Monitoring Payload: %{nef_qos_subscription_test_monitoring_payload}\n
+    # Perform the test
     ${nef_qos_subscription_test_status}=  Test NEF QoS Subscription    %{nef_qos_subscription_test_mini_api_endpoint_to_invoke}    %{nef_qos_subscription_test_reporting_api_ip}    %{nef_qos_subscription_test_reporting_api_port}    %{nef_qos_subscription_test_monitoring_payload}
+    # Log the test results
+    Log    Test Output: ${nef_qos_subscription_test_status}
+    Run Keyword    Log to Console    \nTest Output: ${nef_qos_subscription_test_status}\n
+    # Check if test should pass or fail
     IF  '${nef_qos_subscription_test_status[0]}' in ['0']
         Pass Execution  \n${nef_qos_subscription_test_status[1]}
     ELSE IF  '${nef_qos_subscription_test_status[0]}' in ['1', '2']

--- a/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.robot
+++ b/ftp/tests/nef_qos_subscription_test/nef_qos_subscription_test.robot
@@ -4,7 +4,7 @@ Library    nef_qos_subscription_test.py
 
 *** Test Cases ***
 NEF's QoS Subscription Test
-    ${nef_qos_subscription_test_status}=  Test NEF QoS Subscription    %{nef_qos_subscription_test_mini_api_endpoint_to_invoke}    %{nef_qos_subscription_test_reporting_api_ip}    %{nef_qos_subscription_test_reporting_api_port}
+    ${nef_qos_subscription_test_status}=  Test NEF QoS Subscription    %{nef_qos_subscription_test_mini_api_endpoint_to_invoke}    %{nef_qos_subscription_test_reporting_api_ip}    %{nef_qos_subscription_test_reporting_api_port}    %{nef_qos_subscription_test_monitoring_payload}
     IF  '${nef_qos_subscription_test_status[0]}' in ['0']
         Pass Execution  \n${nef_qos_subscription_test_status[1]}
     ELSE IF  '${nef_qos_subscription_test_status[0]}' in ['1', '2']

--- a/ftp/tests/nef_qos_subscription_test/run_test.sh
+++ b/ftp/tests/nef_qos_subscription_test/run_test.sh
@@ -2,9 +2,48 @@
 # @Author: Eduardo Santos
 # @Date:   2023-12-31 17:02:22
 # @Last Modified by:   Eduardo Santos
-# @Last Modified time: 2023-12-31 18:37:32
+# @Last Modified time: 2024-01-05 19:43:06
 
 export nef_qos_subscription_test_reporting_api_ip=10.255.28.173
 export nef_qos_subscription_test_reporting_api_port=3000
 export nef_qos_subscription_test_mini_api_endpoint_to_invoke=http://10.255.28.206:3001/start/def1145G7
+export nef_qos_subscription_test_monitoring_payload='{"ipv4Addr":"10.0.0.0","ipv6Addr":"0:0:0:0:0:0:0:0","macAddr":"22-00-00-00-00-00","notificationDestination":"http://127.0.0.1/callback","snssai":{"sst":1,"sd":"000001"},"dnn":"province1.mnc01.mcc202.gprs","qosReference":9,"altQoSReferences":[0],"usageThreshold":{"duration":0,"totalVolume":0,"downlinkVolume":0,"uplinkVolume":0},"qosMonInfo":{"reqQosMonParams":["DOWNLINK"],"repFreqs":["EVENT_TRIGGERED"],"latThreshDl":0,"latThreshUl":0,"latThreshRp":0,"waitTime":0,"repPeriod":0}}'
 python3 -m robot .
+
+#nef_qos_subscription_test_monitoring_payload:
+#"
+#{
+#  "ipv4Addr": "10.0.0.0",
+#  "ipv6Addr": "0:0:0:0:0:0:0:0",
+#  "macAddr": "22-00-00-00-00-00",
+#  "notificationDestination": "http://127.0.0.1/callback",
+#  "snssai": {
+#    "sst": 1,
+#    "sd": "000001"
+#  },
+#  "dnn": "province1.mnc01.mcc202.gprs",
+#  "qosReference": 9,
+#  "altQoSReferences": [
+#    0
+#  ],
+#  "usageThreshold": {
+#    "duration": 0,
+#    "totalVolume": 0,
+#    "downlinkVolume": 0,
+#    "uplinkVolume": 0
+#  },
+#  "qosMonInfo": {
+#    "reqQosMonParams": [
+#      "DOWNLINK"
+#    ],
+#    "repFreqs": [
+#      "EVENT_TRIGGERED"
+#    ],
+#    "latThreshDl": 0,
+#    "latThreshUl": 0,
+#    "latThreshRp": 0,
+#    "waitTime": 0,
+#    "repPeriod": 0
+#  }
+#}
+#"

--- a/ftp/tests/nef_qos_subscription_test/run_test.sh
+++ b/ftp/tests/nef_qos_subscription_test/run_test.sh
@@ -2,11 +2,11 @@
 # @Author: Eduardo Santos
 # @Date:   2023-12-31 17:02:22
 # @Last Modified by:   Eduardo Santos
-# @Last Modified time: 2024-01-05 19:43:06
+# @Last Modified time: 2024-01-05 19:49:20
 
 export nef_qos_subscription_test_reporting_api_ip=10.255.28.173
 export nef_qos_subscription_test_reporting_api_port=3000
-export nef_qos_subscription_test_mini_api_endpoint_to_invoke=http://10.255.28.206:3001/start/def1145G7
+export nef_qos_subscription_test_mini_api_endpoint_to_invoke=http://10.255.28.206:8000/start/def1145G7
 export nef_qos_subscription_test_monitoring_payload='{"ipv4Addr":"10.0.0.0","ipv6Addr":"0:0:0:0:0:0:0:0","macAddr":"22-00-00-00-00-00","notificationDestination":"http://127.0.0.1/callback","snssai":{"sst":1,"sd":"000001"},"dnn":"province1.mnc01.mcc202.gprs","qosReference":9,"altQoSReferences":[0],"usageThreshold":{"duration":0,"totalVolume":0,"downlinkVolume":0,"uplinkVolume":0},"qosMonInfo":{"reqQosMonParams":["DOWNLINK"],"repFreqs":["EVENT_TRIGGERED"],"latThreshDl":0,"latThreshUl":0,"latThreshRp":0,"waitTime":0,"repPeriod":0}}'
 python3 -m robot .
 


### PR DESCRIPTION
The def11.5G.7 test now sends the monitoring payload to the MiniAPI through the POST request.

This PR is linked to https://github.com/5gasp/NetworkAppControl-MiniAPI/pull/15

Closes #30 

@rafael-direito, can you please check if the test runs and if everything is as it's supposed to be?