### PR TITLE
Added Def115G4 test implementation

### DIFF
--- a/ftp/tests/nef_ue_rsrp_acquisition_test/nef_ue_rsrp_acquisition_test.py
+++ b/ftp/tests/nef_ue_rsrp_acquisition_test/nef_ue_rsrp_acquisition_test.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# @Author: Rafael Direito
+# @Date:   2023-03-13 15:34:19
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-22 18:41:34
+
+# Return Codes:
+# 0 - Success (PASS)
+# 1 - Test Failed due to errors in the authentication process
+# 2 - Test Failed due to an exception
+
+
+import requests
+import json
+
+
+def validate_report(report, supi):
+    errors = []
+    for i in range(len(report)-1, -1, -1):
+        request = report[i]
+        if (
+            request["endpoint"] == f"/test/api/v1/UEs/{supi}/rsrp" \
+            and 
+            request["method"] == "GET"
+        ):
+            print("Request: ", request)
+            if request["nef_response_code"] not in [200, 409]:
+                errors.append("Invalid Login")
+                break
+        # Other validations...
+        # here
+    return errors
+
+
+def test_nef_acquisiton_of_ue_rsrp(
+    mini_api_endpoint_to_invoke, reporting_api_ip, reporting_api_port, ue_supi
+):
+    # 1. Trigger MiniAPIs endpoint
+    print("Entering...")
+    response = None
+    try:
+        response = requests.post(mini_api_endpoint_to_invoke)
+
+        if response.status_code not in [200, 409]:
+            response.raise_for_status()    
+        print(f"Response: {response.text}")
+    except Exception as e:
+        error = response.text if response else None
+        print(f"Error: {error} - {e}")
+        return 2, error
+
+    # 2. Get NEF's Report
+    try:
+        url = f"http://{reporting_api_ip}:{reporting_api_port}/report"
+        response = requests.get(url)
+    
+        if response.status_code not in [200, 409]:
+            response.raise_for_status()    
+        print(f"Response: {response.text}")
+        report_json = json.loads(response.text)
+        print("NEF's Obtained Report: ")
+        print(json.dumps(report_json, indent=4))
+        
+        errors = validate_report(report_json, ue_supi)
+        
+    except Exception as e:
+        error = response.text if response else None
+        print(f"Error: {error} - {e}")
+        return 2, error
+
+
+    # 6. Validate Report
+    errors = validate_report(report_json, ue_supi)
+
+    if len(errors) != 0:
+        errors_str = '\n\t- '.join(errors)
+        print(f"Test Failed due to the following errors: {errors_str}")
+        return 1, f"Test Failed due to the following errors: {errors_str}"
+
+    print("Test Successful! NApp was able to get an UE's RSPP")
+    return 0, "Test Successful! NApp was able to get an UE's RSRP"

--- a/ftp/tests/nef_ue_rsrp_acquisition_test/nef_ue_rsrp_acquisition_test.robot
+++ b/ftp/tests/nef_ue_rsrp_acquisition_test/nef_ue_rsrp_acquisition_test.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Library    nef_ue_rsrp_acquisition_test.py
+
+
+*** Test Cases ***
+NEF's Acquisiton of UE RSRP
+    ${nef_ue_rsrp_acquisition_test_status}=  Test NEF Acquisiton of UE RSRP    %{nef_ue_rsrp_acquisition_test_mini_api_endpoint_to_invoke}    %{nef_ue_rsrp_acquisition_test_reporting_api_ip}    %{nef_ue_rsrp_acquisition_test_reporting_api_port}    %{nef_ue_rsrp_acquisition_test_ue_supi} 
+    IF  '${nef_ue_rsrp_acquisition_test_status[0]}' in ['0']
+        Pass Execution  \n${nef_ue_rsrp_acquisition_test_status[1]}
+    ELSE IF  '${nef_ue_rsrp_acquisition_test_status[0]}' in ['1', '2']
+        Fail  \n${nef_ue_rsrp_acquisition_test_status[1]}
+    ELSE
+        Fail  \nUnknown Error
+    END

--- a/ftp/tests/nef_ue_rsrp_acquisition_test/run_test.sh
+++ b/ftp/tests/nef_ue_rsrp_acquisition_test/run_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# @Author: Rafael Direito
+# @Date:   2023-05-22 15:42:35
+# @Last Modified by:   Rafael Direito
+# @Last Modified time: 2024-01-22 18:38:38
+
+export nef_ue_rsrp_acquisition_test_reporting_api_ip=10.255.28.236
+export nef_ue_rsrp_acquisition_test_reporting_api_port=3000
+export nef_ue_rsrp_acquisition_test_mini_api_endpoint_to_invoke=http://10.255.28.230:3001/start/Def115G4
+export nef_ue_rsrp_acquisition_test_ue_supi=202010000000001
+python3 -m robot .


### PR DESCRIPTION
(Closes #35 )

**[def11.5G.4]**
**Test Case:** Acquisition of UE Reference Signal Received Power (RSRP) information
**Test Description:** This test will validate that a Network Application is able to retrieve indicative information about RSRP

@eduardosantoshf
Can you please review this?
Before executing this test you must first run 2 others:
* Mini API Configuration
* NEF's Authentication Test (to force the authentication)

When reviewing this PR, take into consideration this other one: https://github.com/5gasp/NetworkAppControl-MiniAPI/pull/20